### PR TITLE
 feat: [AUTH-4354] Consumer JWT Session Authenticate manual method

### DIFF
--- a/Stytch.net.Tests/Clients/M2M.cs
+++ b/Stytch.net.Tests/Clients/M2M.cs
@@ -7,16 +7,20 @@ namespace Stytch.net.Tests.Clients;
 
 public class M2M : TestBase
 {
+
+    private readonly Task<M2MTokenResponse> tokenResTask;
+    public M2M() : base()
+    {
+        // A (temporary) hack - we do not support sandbox values for M2M so we provisioned a client 
+        // that reuses the Project ID and Project Secret values we already have saved in CI 
+        tokenResTask = consumerClient.M2M.Token(new M2MTokenRequest(_clientConfig.ProjectId, _clientConfig.ProjectSecret));
+    }
+
     [Fact]
     public async Task M2MToken_Success()
     {
         // Arrange
-        var client = new Stytch.net.Clients.ConsumerClient(_clientConfig);
-
-        // Act
-        // A (temporary) hack - we do not support sandbox values for M2M so we provisioned a client 
-        // that reuses the Project ID and Project Secret values we already have saved in CI 
-        var res = await client.M2M.Token(new M2MTokenRequest(_clientConfig.ProjectId, _clientConfig.ProjectSecret));
+        var res = await tokenResTask;
 
         // Assert
         Assert.NotEmpty(res.AccessToken);
@@ -28,12 +32,11 @@ public class M2M : TestBase
     public async Task M2MAuthenticateToken_Success()
     {
         // Arrange
-        var client = new Stytch.net.Clients.ConsumerClient(_clientConfig);
+        var tokenRes = await tokenResTask;
 
         // Act
-        var tokenRes = await client.M2M.Token(new M2MTokenRequest(_clientConfig.ProjectId, _clientConfig.ProjectSecret));
 
-        var authRes = await client.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken));
+        var authRes = await consumerClient.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken));
 
         // Assert
         Assert.NotNull(authRes);
@@ -46,15 +49,12 @@ public class M2M : TestBase
     public async Task M2MAuthenticateToken_FailureInvalidSignature()
     {
         // Arrange
-        var client = new Stytch.net.Clients.ConsumerClient(_clientConfig);
-
-        // Act
-        var tokenRes = await client.M2M.Token(new M2MTokenRequest(_clientConfig.ProjectId, _clientConfig.ProjectSecret));
+        var tokenRes = await tokenResTask;
 
         // Assert
         await Assert.ThrowsAsync<SecurityTokenInvalidSignatureException>(() =>
         {
-            return client.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest($"{tokenRes.AccessToken}garbage"));
+            return consumerClient.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest($"{tokenRes.AccessToken}garbage"));
         });
     }
 
@@ -62,12 +62,10 @@ public class M2M : TestBase
     public async Task M2MAuthenticateToken_SuccessWithRequiredScopes()
     {
         // Arrange
-        var client = new Stytch.net.Clients.ConsumerClient(_clientConfig);
+        var tokenRes = await tokenResTask;
 
         // Act
-        var tokenRes = await client.M2M.Token(new M2MTokenRequest(_clientConfig.ProjectId, _clientConfig.ProjectSecret));
-
-        var authRes = await client.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken)
+        var authRes = await consumerClient.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken)
         {
             RequiredScopes = new List<string> { "read:users" }
         });
@@ -80,15 +78,12 @@ public class M2M : TestBase
     public async Task M2MAuthenticateToken_FailureOnMissingScopes()
     {
         // Arrange
-        var client = new Stytch.net.Clients.ConsumerClient(_clientConfig);
-
-        // Act
-        var tokenRes = await client.M2M.Token(new M2MTokenRequest(_clientConfig.ProjectId, _clientConfig.ProjectSecret));
+        var tokenRes = await tokenResTask;
 
         // Act
         var exception = await Assert.ThrowsAsync<StytchMissingScopesException>(() =>
         {
-            return client.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken)
+            return consumerClient.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken)
             {
                 RequiredScopes = new List<string> { "read:users", "superadmin" }
             });
@@ -103,18 +98,16 @@ public class M2M : TestBase
     public async Task M2MAuthenticateToken_SuccessWithLifetimeValidation()
     {
         // Arrange
-        var client = new Stytch.net.Clients.ConsumerClient(_clientConfig);
+        var tokenRes = await tokenResTask;
 
         // Act
-        var tokenRes = await client.M2M.Token(new M2MTokenRequest(_clientConfig.ProjectId, _clientConfig.ProjectSecret));
-
         bool LifetimeValidator(DateTime? notbefore, DateTime? expires, SecurityToken securitytoken,
             TokenValidationParameters validationparameters)
         {
             return DateTime.UtcNow > notbefore && DateTime.UtcNow < expires;
         }
 
-        var authRes = await client.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken)
+        var authRes = await consumerClient.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken)
         {
             LifetimeValidator = LifetimeValidator
         });
@@ -128,10 +121,7 @@ public class M2M : TestBase
     public async Task M2MAuthenticateToken_FailureOnLifetimeValidation()
     {
         // Arrange
-        var client = new Stytch.net.Clients.ConsumerClient(_clientConfig);
-
-        // Act
-        var tokenRes = await client.M2M.Token(new M2MTokenRequest(_clientConfig.ProjectId, _clientConfig.ProjectSecret));
+        var tokenRes = await tokenResTask;
 
         // Act
         var exception = await Assert.ThrowsAsync<SecurityTokenInvalidLifetimeException>(() =>
@@ -142,7 +132,7 @@ public class M2M : TestBase
                 return false;
             }
 
-            return client.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken)
+            return consumerClient.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken)
             {
                 RequiredScopes = new List<string> { "read:users", "superadmin" },
                 LifetimeValidator = LifetimeValidator

--- a/Stytch.net.Tests/Clients/TestBase.cs
+++ b/Stytch.net.Tests/Clients/TestBase.cs
@@ -6,6 +6,7 @@ public class TestBase
 {
 
     protected readonly ClientConfig _clientConfig;
+    protected readonly net.Clients.ConsumerClient consumerClient;
 
     public TestBase()
     {
@@ -26,5 +27,13 @@ public class TestBase
             ProjectId = projectId,
             ProjectSecret = projectSecret,
         };
+
+        consumerClient = new Stytch.net.Clients.ConsumerClient(_clientConfig);
+    }
+
+
+    protected void AssertEqualTimestamps(DateTime? first, DateTime? second)
+    {
+        Assert.Equal(Assert.NotNull(first), Assert.NotNull(second), TimeSpan.FromSeconds(2));
     }
 }

--- a/Stytch.net/Clients/consumer/M2M.cs
+++ b/Stytch.net/Clients/consumer/M2M.cs
@@ -14,6 +14,8 @@ using System.Text;
 using System.Threading.Tasks;
 
 
+
+
 namespace Stytch.net.Clients.Consumer
 {
     public class M2M
@@ -21,7 +23,6 @@ namespace Stytch.net.Clients.Consumer
         private readonly ClientConfig _config;
         private readonly HttpClient _httpClient;
         public readonly M2MClients Clients;
-
         public M2M(HttpClient client, ClientConfig config)
         {
             _httpClient = client;
@@ -43,12 +44,10 @@ namespace Stytch.net.Clients.Consumer
             M2MTokenRequest request
         )
         {
-            var formData = new Dictionary<string, string>
-            {
-                { "client_id", request.ClientId },
-                { "client_secret", request.ClientSecret },
-                { "grant_type", "client_credentials" }
-            };
+            var formData = new Dictionary<string, string>();
+            formData.Add("client_id", request.ClientId);
+            formData.Add("client_secret", request.ClientSecret);
+            formData.Add("grant_type", "client_credentials");
 
             if (request.Scopes != null && request.Scopes.Count > 0)
             {
@@ -81,12 +80,9 @@ namespace Stytch.net.Clients.Consumer
 
         // MANUAL(authenticateToken)(SERVICE_METHOD)
         /// <summary>
-        /// Retrieve an access token for the given M2M Client.
-        /// Access tokens are JWTs signed with the project's JWKS, and are valid for one hour after issuance.
-        /// M2M Access tokens contain a standard set of claims as well as any custom claims generated from templates.
-        /// 
-        /// M2M Access tokens can be validated locally using the Authenticate Access Token method in the Stytch Backend SDKs,
-        /// or with any library that supports JWT signature validation.
+        /// Authenticate an access token issued by Stytch from the Token endpoint.
+        /// M2M access tokens are JWTs signed with the project's JWKs, and can be validated locally using any Stytch client library.
+        /// You may pass in an optional set of scopes that the JWT must contain in order to enforce permissions.
         /// </summary>
         public async Task<M2MAuthenticateTokenResponse> AuthenticateToken(
             M2MAuthenticateTokenRequest request
@@ -132,5 +128,9 @@ namespace Stytch.net.Clients.Consumer
             };
         }
         // ENDMANUAL(authenticateToken)
+
+
     }
+
 }
+

--- a/Stytch.net/Clients/consumer/Sessions.cs
+++ b/Stytch.net/Clients/consumer/Sessions.cs
@@ -13,6 +13,8 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
+using JsonException = Newtonsoft.Json.JsonException;
+using System.Text.Json;
 
 
 
@@ -245,6 +247,81 @@ namespace Stytch.net.Clients.Consumer
                 throw new StytchNetworkException($"Unexpected error occurred: {responseBody}", response);
             }
         }
+
+        // MANUAL(AuthenticateJWT)(SERVICE_METHOD)
+        // ADDIMPORT: using System.Text.Json;
+        // ADDIMPORT: using JsonException = Newtonsoft.Json.JsonException;
+        /// <summary>
+        /// Parse a JWT and verify the signature, preferring local verification to remote.
+        /// </summary>
+        public async Task<Session> AuthenticateJwt(
+            AuthenticateJwtRequest request)
+        {
+            try
+            {
+                return await AuthenticateJwtLocal(new AuthenticateJwtLocalRequest(request.SessionJwt)
+                {
+                    ClockSkew = request.ClockSkew,
+                    LifetimeValidator = request.LifetimeValidator,
+                });
+            }
+            catch
+            {
+                var networkResponse = await Authenticate(new SessionsAuthenticateRequest
+                {
+                    SessionJwt = request.SessionJwt,
+                });
+                return networkResponse.Session;
+            }
+        }
+
+        /// <summary>
+        /// The SessionJWTModel is an intermediate representation of the Session as stored in the JWT.
+        /// It differs from the typical JSON API Response session in the following ways:
+        /// - SessionId is stored as "id" instead of "session_id"
+        /// - No user ID is present - it is stored under the "sub" claim 
+        /// </summary>
+        private class SessionJWTModel : Session
+        {
+            [JsonProperty("id")] public new string SessionId { get; set; }
+
+            public Session ToSession(string userId)
+            {
+                return new Session
+                {
+                    SessionId = SessionId,
+                    UserId = userId,
+                    AuthenticationFactors = AuthenticationFactors,
+                    StartedAt = StartedAt,
+                    LastAccessedAt = LastAccessedAt,
+                    ExpiresAt = ExpiresAt,
+                    Attributes = Attributes,
+                    CustomClaims = CustomClaims
+                };
+            }
+        }
+
+        /// <summary>
+        /// Parse a JWT and verify the signature locally (without calling /authenticate in the API).
+        /// </summary>
+        public async Task<Session> AuthenticateJwtLocal(
+            AuthenticateJwtLocalRequest request
+        )
+        {
+            var res = await Utility.AuthenticateJwtLocal(_httpClient, _config, new Utility.AuthenticateJwtParams
+            {
+                Jwt = request.SessionJwt,
+                ClockSkew = request.ClockSkew,
+                LifetimeValidator = request.LifetimeValidator
+            });
+
+            var sessionJsonEl = (JsonElement)res.CustomClaims["https://stytch.com/session"];
+
+            return JsonConvert.DeserializeObject<SessionJWTModel>(sessionJsonEl.GetRawText())
+                .ToSession(res.Subject);
+        }
+        // ENDMANUAL(AuthenticateJWT)
+
 
     }
 

--- a/Stytch.net/Models/Consumer/Sessions.cs
+++ b/Stytch.net/Models/Consumer/Sessions.cs
@@ -9,6 +9,7 @@ using System;
 using System.Runtime.Serialization;
 using System.Collections.Generic;
 
+using Microsoft.IdentityModel.Tokens;
 
 namespace Stytch.net.Models.Consumer
 {
@@ -967,4 +968,34 @@ namespace Stytch.net.Models.Consumer
         [EnumMember(Value = "recovery_codes")]
         RECOVERY_CODES,
     }
+    // MANUAL(AuthenticateJWT)(TYPES)
+    // ADDIMPORT: using Microsoft.IdentityModel.Tokens;
+    public class AuthenticateJwtRequest
+    {
+        public string SessionJwt { get; set; }
+        public TimeSpan ClockSkew { get; set; } = TimeSpan.FromMinutes(1);
+
+        public LifetimeValidator LifetimeValidator { get; set; }
+
+        public AuthenticateJwtRequest(string sessionJwt)
+        {
+            SessionJwt = sessionJwt;
+        }
+    }
+
+    public class AuthenticateJwtLocalRequest
+    {
+        public string SessionJwt { get; set; }
+        public TimeSpan ClockSkew { get; set; } = TimeSpan.FromMinutes(1);
+
+        public LifetimeValidator LifetimeValidator { get; set; }
+
+        public AuthenticateJwtLocalRequest(string sessionJwt)
+        {
+            SessionJwt = sessionJwt;
+        }
+    }
+
+    // ENDMANUAL(AuthenticateJWT)
+
 }


### PR DESCRIPTION
Part of AUTH-4354.

This PR adds support for a Consumer `Sessions.AuthenticateJwt` / `AuthenticateJwtLocal` manual method, like we have in other client libraries. 

This PR also contains some test cleanup and some small fixes to M2M - I suggest reviewing it commit by commit.  