### PR TITLE
 fix: Codegen errors in path params

### DIFF
--- a/Stytch.net.Tests/Clients/B2BClient.cs
+++ b/Stytch.net.Tests/Clients/B2BClient.cs
@@ -1,0 +1,13 @@
+using Stytch.net.Models.Consumer;
+
+namespace Stytch.net.Tests.Clients;
+
+public class B2BClient : B2BTestBase
+{
+    [Fact]
+    public async void GetJwks_ShouldSucceed()
+    {
+        var jwksRes = await b2bClient.Sessions.GetJWKS(new B2BSessionsGetJWKSRequest(_clientConfig.ProjectId));
+        Assert.NotEmpty(jwksRes.Keys);
+    }
+}

--- a/Stytch.net/Clients/b2b/Organizations.cs
+++ b/Stytch.net/Clients/b2b/Organizations.cs
@@ -87,7 +87,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -125,7 +125,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -174,7 +174,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -262,7 +262,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/metrics"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/metrics"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/b2b/OrganizationsMembers.cs
+++ b/Stytch.net/Clients/b2b/OrganizationsMembers.cs
@@ -41,7 +41,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -89,7 +89,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -138,7 +138,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}/reactivate"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}/reactivate"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -195,7 +195,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/mfa_phone_numbers/${request.MemberId}"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/mfa_phone_numbers/{request.MemberId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -249,7 +249,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}/totp"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}/totp"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -348,7 +348,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/passwords/${request.MemberPasswordId}"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/passwords/{request.MemberPasswordId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -398,7 +398,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/members/dangerously_get/${request.MemberId}"
+                Path = $"/v1/b2b/organizations/members/dangerously_get/{request.MemberId}"
             };
             uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string> {
             {"include_deleted", (request.IncludeDeleted).ToString().ToLower()},
@@ -433,7 +433,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}/oidc_providers"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}/oidc_providers"
             };
             uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string> {
             {"include_refresh_token", (request.IncludeRefreshToken).ToString().ToLower()},
@@ -487,7 +487,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}/unlink_retired_email"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}/unlink_retired_email"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -535,7 +535,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -582,7 +582,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/member"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/member"
             };
             uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string> {
             {"member_id", request.MemberId},

--- a/Stytch.net/Clients/b2b/OrganizationsMembersOAuthProviders.cs
+++ b/Stytch.net/Clients/b2b/OrganizationsMembersOAuthProviders.cs
@@ -49,7 +49,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}/oauth_providers/google"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}/oauth_providers/google"
             };
             uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string> {
             {"include_refresh_token", (request.IncludeRefreshToken).ToString().ToLower()},
@@ -88,7 +88,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}/oauth_providers/microsoft"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}/oauth_providers/microsoft"
             };
             uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string> {
             {"include_refresh_token", (request.IncludeRefreshToken).ToString().ToLower()},
@@ -123,7 +123,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}/oauth_providers/slack"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}/oauth_providers/slack"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -155,7 +155,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}/oauth_providers/hubspot"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}/oauth_providers/hubspot"
             };
             uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string> {
             {"include_refresh_token", (request.IncludeRefreshToken).ToString().ToLower()},
@@ -190,7 +190,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/organizations/${request.OrganizationId}/members/${request.MemberId}/oauth_providers/github"
+                Path = $"/v1/b2b/organizations/{request.OrganizationId}/members/{request.MemberId}/oauth_providers/github"
             };
             uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string> {
             {"include_refresh_token", (request.IncludeRefreshToken).ToString().ToLower()},

--- a/Stytch.net/Clients/b2b/RecoveryCodes.cs
+++ b/Stytch.net/Clients/b2b/RecoveryCodes.cs
@@ -78,7 +78,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/recovery_codes/${request.OrganizationId}/${request.MemberId}"
+                Path = $"/v1/b2b/recovery_codes/{request.OrganizationId}/{request.MemberId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/b2b/SCIMConnection.cs
+++ b/Stytch.net/Clients/b2b/SCIMConnection.cs
@@ -39,7 +39,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/scim/${request.OrganizationId}/connection/${request.ConnectionId}"
+                Path = $"/v1/b2b/scim/{request.OrganizationId}/connection/{request.ConnectionId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -87,7 +87,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/scim/${request.OrganizationId}/connection/${request.ConnectionId}"
+                Path = $"/v1/b2b/scim/{request.OrganizationId}/connection/{request.ConnectionId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -135,7 +135,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/scim/${request.OrganizationId}/connection/${request.ConnectionId}/rotate/start"
+                Path = $"/v1/b2b/scim/{request.OrganizationId}/connection/{request.ConnectionId}/rotate/start"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -185,7 +185,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/scim/${request.OrganizationId}/connection/${request.ConnectionId}/rotate/complete"
+                Path = $"/v1/b2b/scim/{request.OrganizationId}/connection/{request.ConnectionId}/rotate/complete"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -234,7 +234,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/scim/${request.OrganizationId}/connection/${request.ConnectionId}/rotate/cancel"
+                Path = $"/v1/b2b/scim/{request.OrganizationId}/connection/{request.ConnectionId}/rotate/cancel"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -282,7 +282,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/scim/${request.OrganizationId}/connection/${request.ConnectionId}"
+                Path = $"/v1/b2b/scim/{request.OrganizationId}/connection/{request.ConnectionId}"
             };
             uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string> {
             {"cursor", request.Cursor},
@@ -327,7 +327,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/scim/${request.OrganizationId}/connection"
+                Path = $"/v1/b2b/scim/{request.OrganizationId}/connection"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -375,7 +375,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/scim/${request.OrganizationId}/connection"
+                Path = $"/v1/b2b/scim/{request.OrganizationId}/connection"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/b2b/SSO.cs
+++ b/Stytch.net/Clients/b2b/SSO.cs
@@ -45,7 +45,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/${request.OrganizationId}"
+                Path = $"/v1/b2b/sso/{request.OrganizationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -86,7 +86,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/${request.OrganizationId}/connections/${request.ConnectionId}"
+                Path = $"/v1/b2b/sso/{request.OrganizationId}/connections/{request.ConnectionId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/b2b/SSOExternal.cs
+++ b/Stytch.net/Clients/b2b/SSOExternal.cs
@@ -39,7 +39,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/external/${request.OrganizationId}"
+                Path = $"/v1/b2b/sso/external/{request.OrganizationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -87,7 +87,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/external/${request.OrganizationId}/connections/${request.ConnectionId}"
+                Path = $"/v1/b2b/sso/external/{request.OrganizationId}/connections/{request.ConnectionId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/b2b/SSOOIDC.cs
+++ b/Stytch.net/Clients/b2b/SSOOIDC.cs
@@ -39,7 +39,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/oidc/${request.OrganizationId}"
+                Path = $"/v1/b2b/sso/oidc/{request.OrganizationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -112,7 +112,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/oidc/${request.OrganizationId}/connections/${request.ConnectionId}"
+                Path = $"/v1/b2b/sso/oidc/{request.OrganizationId}/connections/{request.ConnectionId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/b2b/SSOSAML.cs
+++ b/Stytch.net/Clients/b2b/SSOSAML.cs
@@ -39,7 +39,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/saml/${request.OrganizationId}"
+                Path = $"/v1/b2b/sso/saml/{request.OrganizationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -93,7 +93,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/saml/${request.OrganizationId}/connections/${request.ConnectionId}"
+                Path = $"/v1/b2b/sso/saml/{request.OrganizationId}/connections/{request.ConnectionId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -147,7 +147,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/saml/${request.OrganizationId}/connections/${request.ConnectionId}/url"
+                Path = $"/v1/b2b/sso/saml/{request.OrganizationId}/connections/{request.ConnectionId}/url"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -198,7 +198,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sso/saml/${request.OrganizationId}/connections/${request.ConnectionId}/verification_certificates/${request.CertificateId}"
+                Path = $"/v1/b2b/sso/saml/{request.OrganizationId}/connections/{request.ConnectionId}/verification_certificates/{request.CertificateId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/b2b/Sessions.cs
+++ b/Stytch.net/Clients/b2b/Sessions.cs
@@ -11,9 +11,11 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
+
 using JsonException = Newtonsoft.Json.JsonException;
+using System.Text.Json;
+
 
 
 namespace Stytch.net.Clients.B2B
@@ -22,7 +24,6 @@ namespace Stytch.net.Clients.B2B
     {
         private readonly ClientConfig _config;
         private readonly HttpClient _httpClient;
-
         public Sessions(HttpClient client, ClientConfig config)
         {
             _httpClient = client;
@@ -41,11 +42,10 @@ namespace Stytch.net.Clients.B2B
             {
                 Path = $"/v1/b2b/sessions"
             };
-            uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string>
-            {
-                { "organization_id", request.OrganizationId },
-                { "member_id", request.MemberId },
-            });
+            uriBuilder.Query = Utility.BuildQueryString(new Dictionary<string, string> {
+            {"organization_id", request.OrganizationId},
+            {"member_id", request.MemberId},
+        });
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
 
@@ -56,7 +56,6 @@ namespace Stytch.net.Clients.B2B
             {
                 return JsonConvert.DeserializeObject<B2BSessionsGetResponse>(responseBody);
             }
-
             try
             {
                 var apiException = JsonConvert.DeserializeObject<StytchApiException>(responseBody);
@@ -67,7 +66,6 @@ namespace Stytch.net.Clients.B2B
                 throw new StytchNetworkException($"Unexpected error occurred: {responseBody}", response);
             }
         }
-
         /// <summary>
         /// Authenticates a Session and updates its lifetime by the specified `session_duration_minutes`. If the
         /// `session_duration_minutes` is not specified, a Session will not be extended. This endpoint requires
@@ -117,7 +115,6 @@ namespace Stytch.net.Clients.B2B
             {
                 return JsonConvert.DeserializeObject<B2BSessionsAuthenticateResponse>(responseBody);
             }
-
             try
             {
                 var apiException = JsonConvert.DeserializeObject<StytchApiException>(responseBody);
@@ -128,7 +125,6 @@ namespace Stytch.net.Clients.B2B
                 throw new StytchNetworkException($"Unexpected error occurred: {responseBody}", response);
             }
         }
-
         /// <summary>
         /// Revoke a Session and immediately invalidate all its tokens. To revoke a specific Session, pass either
         /// the `member_session_id`, `session_token`, or `session_jwt`. To revoke all Sessions for a Member, pass
@@ -157,7 +153,6 @@ namespace Stytch.net.Clients.B2B
             {
                 httpReq.Headers.Add("X-Stytch-Member-Session", options.Authorization.SessionToken);
             }
-
             if (!string.IsNullOrEmpty(options.Authorization.SessionJwt))
             {
                 httpReq.Headers.Add("X-Stytch-Member-SessionJWT", options.Authorization.SessionJwt);
@@ -170,7 +165,6 @@ namespace Stytch.net.Clients.B2B
             {
                 return JsonConvert.DeserializeObject<B2BSessionsRevokeResponse>(responseBody);
             }
-
             try
             {
                 var apiException = JsonConvert.DeserializeObject<StytchApiException>(responseBody);
@@ -181,7 +175,6 @@ namespace Stytch.net.Clients.B2B
                 throw new StytchNetworkException($"Unexpected error occurred: {responseBody}", response);
             }
         }
-
         /// <summary>
         /// Use this endpoint to exchange a Member's existing session for another session in a different
         /// Organization. This can be used to accept an invite, but not to create a new member via domain matching.
@@ -233,7 +226,6 @@ namespace Stytch.net.Clients.B2B
             {
                 return JsonConvert.DeserializeObject<B2BSessionsExchangeResponse>(responseBody);
             }
-
             try
             {
                 var apiException = JsonConvert.DeserializeObject<StytchApiException>(responseBody);
@@ -244,7 +236,6 @@ namespace Stytch.net.Clients.B2B
                 throw new StytchNetworkException($"Unexpected error occurred: {responseBody}", response);
             }
         }
-
         /// <summary>
         /// Migrate a session from an external OIDC compliant endpoint. Stytch will call the external UserInfo
         /// endpoint defined in your Stytch Project settings in the [Dashboard](/dashboard), and then perform a
@@ -278,7 +269,6 @@ namespace Stytch.net.Clients.B2B
             {
                 return JsonConvert.DeserializeObject<B2BSessionsMigrateResponse>(responseBody);
             }
-
             try
             {
                 var apiException = JsonConvert.DeserializeObject<StytchApiException>(responseBody);
@@ -289,7 +279,6 @@ namespace Stytch.net.Clients.B2B
                 throw new StytchNetworkException($"Unexpected error occurred: {responseBody}", response);
             }
         }
-
         /// <summary>
         /// Get the JSON Web Key Set (JWKS) for a project.
         /// 
@@ -318,7 +307,7 @@ namespace Stytch.net.Clients.B2B
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/b2b/sessions/jwks/${request.ProjectId}"
+                Path = $"/v1/b2b/sessions/jwks/{request.ProjectId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -330,7 +319,6 @@ namespace Stytch.net.Clients.B2B
             {
                 return JsonConvert.DeserializeObject<B2BSessionsGetJWKSResponse>(responseBody);
             }
-
             try
             {
                 var apiException = JsonConvert.DeserializeObject<StytchApiException>(responseBody);
@@ -456,5 +444,9 @@ namespace Stytch.net.Clients.B2B
             return memberSession;
         }
         // ENDMANUAL(AuthenticateJWT)
+
+
     }
+
 }
+

--- a/Stytch.net/Clients/consumer/M2M.cs
+++ b/Stytch.net/Clients/consumer/M2M.cs
@@ -14,6 +14,8 @@ using System.Text;
 using System.Threading.Tasks;
 
 
+
+
 namespace Stytch.net.Clients.Consumer
 {
     public class M2M
@@ -21,7 +23,6 @@ namespace Stytch.net.Clients.Consumer
         private readonly ClientConfig _config;
         private readonly HttpClient _httpClient;
         public readonly M2MClients Clients;
-
         public M2M(HttpClient client, ClientConfig config)
         {
             _httpClient = client;
@@ -127,5 +128,9 @@ namespace Stytch.net.Clients.Consumer
             };
         }
         // ENDMANUAL(authenticateToken)
+
+
     }
+
 }
+

--- a/Stytch.net/Clients/consumer/M2MClients.cs
+++ b/Stytch.net/Clients/consumer/M2MClients.cs
@@ -40,7 +40,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/m2m/clients/${request.ClientId}"
+                Path = $"/v1/m2m/clients/{request.ClientId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -124,7 +124,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/m2m/clients/${request.ClientId}"
+                Path = $"/v1/m2m/clients/{request.ClientId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -168,7 +168,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/m2m/clients/${request.ClientId}"
+                Path = $"/v1/m2m/clients/{request.ClientId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/consumer/M2MClientsSecrets.cs
+++ b/Stytch.net/Clients/consumer/M2MClientsSecrets.cs
@@ -48,7 +48,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/m2m/clients/${request.ClientId}/secrets/rotate/start"
+                Path = $"/v1/m2m/clients/{request.ClientId}/secrets/rotate/start"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -91,7 +91,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/m2m/clients/${request.ClientId}/secrets/rotate/cancel"
+                Path = $"/v1/m2m/clients/{request.ClientId}/secrets/rotate/cancel"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -134,7 +134,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Post;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/m2m/clients/${request.ClientId}/secrets/rotate"
+                Path = $"/v1/m2m/clients/{request.ClientId}/secrets/rotate"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/consumer/Sessions.cs
+++ b/Stytch.net/Clients/consumer/Sessions.cs
@@ -225,7 +225,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/sessions/jwks/${request.ProjectId}"
+                Path = $"/v1/sessions/jwks/{request.ProjectId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/consumer/Users.cs
+++ b/Stytch.net/Clients/consumer/Users.cs
@@ -78,7 +78,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Get;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/${request.UserId}"
+                Path = $"/v1/users/{request.UserId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -158,7 +158,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/${request.UserId}"
+                Path = $"/v1/users/{request.UserId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -204,7 +204,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/${request.UserId}/exchange_primary_factor"
+                Path = $"/v1/users/{request.UserId}/exchange_primary_factor"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -243,7 +243,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/${request.UserId}"
+                Path = $"/v1/users/{request.UserId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -282,7 +282,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/emails/${request.EmailId}"
+                Path = $"/v1/users/emails/{request.EmailId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -321,7 +321,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/phone_numbers/${request.PhoneId}"
+                Path = $"/v1/users/phone_numbers/{request.PhoneId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -360,7 +360,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/webauthn_registrations/${request.WebAuthnRegistrationId}"
+                Path = $"/v1/users/webauthn_registrations/{request.WebAuthnRegistrationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -399,7 +399,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/biometric_registrations/${request.BiometricRegistrationId}"
+                Path = $"/v1/users/biometric_registrations/{request.BiometricRegistrationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -438,7 +438,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/totps/${request.TOTPId}"
+                Path = $"/v1/users/totps/{request.TOTPId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -477,7 +477,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/crypto_wallets/${request.CryptoWalletId}"
+                Path = $"/v1/users/crypto_wallets/{request.CryptoWalletId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -516,7 +516,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/passwords/${request.PasswordId}"
+                Path = $"/v1/users/passwords/{request.PasswordId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());
@@ -555,7 +555,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Delete;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/users/oauth/${request.OAuthUserRegistrationId}"
+                Path = $"/v1/users/oauth/{request.OAuthUserRegistrationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Clients/consumer/WebAuthn.cs
+++ b/Stytch.net/Clients/consumer/WebAuthn.cs
@@ -238,7 +238,7 @@ namespace Stytch.net.Clients.Consumer
             var method = HttpMethod.Put;
             var uriBuilder = new UriBuilder(_httpClient.BaseAddress)
             {
-                Path = $"/v1/webauthn/${request.WebAuthnRegistrationId}"
+                Path = $"/v1/webauthn/{request.WebAuthnRegistrationId}"
             };
 
             var httpReq = new HttpRequestMessage(method, uriBuilder.ToString());

--- a/Stytch.net/Models/B2B/Sessions.cs
+++ b/Stytch.net/Models/B2B/Sessions.cs
@@ -8,8 +8,8 @@ using Newtonsoft.Json.Converters;
 using System;
 using System.Runtime.Serialization;
 using System.Collections.Generic;
-using Microsoft.IdentityModel.Tokens;
 
+using Microsoft.IdentityModel.Tokens;
 
 namespace Stytch.net.Models.Consumer
 {
@@ -634,7 +634,6 @@ namespace Stytch.net.Models.Consumer
         [EnumMember(Value = "pt-br")]
         PTBR,
     }
-
     // MANUAL(AuthenticateJWT)(TYPES)
     // ADDIMPORT: using Microsoft.IdentityModel.Tokens;
     public class B2BAuthenticateJwtRequest
@@ -728,4 +727,5 @@ namespace Stytch.net.Models.Consumer
     }
 
     // ENDMANUAL(AuthenticateJWT)
+
 }


### PR DESCRIPTION
We were leaving the `$` prefix on our path params during codegen - this breaks any endpoint with path params!

Depends on #12  