### PR TITLE
Refresh RBAC policy in background process

### DIFF
--- a/Stytch.net/Stytch.net.csproj
+++ b/Stytch.net/Stytch.net.csproj
@@ -8,7 +8,7 @@
 <PackageId>Stytch.net</PackageId>
 <AssemblyTitle>Stytch.net</AssemblyTitle>
 <AssemblyName>Stytch.net</AssemblyName>
-    <Version>2.4.0</Version>
+    <Version>2.5.0</Version>
 <Author>Stytch</Author>
 <Product>Stytch</Product>
 <PackageProjectUrl>https://github.com/stytchauth/stytch-dotnet</PackageProjectUrl>


### PR DESCRIPTION
With this change, policy refreshes happen in a background process, meaning only the *first* call will deal with increased latency.