### PR TITLE
Support custom domains for JWT issuer validation

### DIFF
--- a/Stytch.net.Tests/Clients/M2M.cs
+++ b/Stytch.net.Tests/Clients/M2M.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Microsoft.IdentityModel.Tokens;
-using Stytch.net.Clients;
 using Stytch.net.Exceptions;
 using Stytch.net.Models;
 
@@ -135,41 +134,5 @@ public class M2M : ConsumerTestBase, IAsyncLifetime
 
         // Assert
         Assert.NotNull(exception);
-    }
-
-    [Fact]
-    public async Task M2MAuthenticateToken_SuccessWithCustomDomain()
-    {
-        // This test verifies that when a custom domain is configured,
-        // the AuthenticateJwtLocal method accepts tokens with custom issuers
-        // Note: This test uses standard Stytch tokens, but documents the custom domain support
-
-        // Arrange - Create a client config with custom domain
-        string? projectId = Environment.GetEnvironmentVariable("PROJECT_ID");
-        string? projectSecret = Environment.GetEnvironmentVariable("PROJECT_SECRET");
-
-        if (string.IsNullOrEmpty(projectId) || string.IsNullOrEmpty(projectSecret))
-        {
-            throw new InvalidOperationException("Required environment variables not set.");
-        }
-
-        var customConfig = new ClientConfig
-        {
-            ProjectId = projectId,
-            ProjectSecret = projectSecret,
-            CustomBaseUrl = "https://login.example.com" // Custom domain that would issue tokens
-        };
-
-        var customClient = new Stytch.net.Clients.ConsumerClient(customConfig);
-
-        // Act - Authenticate with standard token (custom domain tokens would work the same way)
-        var authRes = await customClient.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken));
-
-        // Assert - Token validation succeeds with custom domain configured
-        Assert.NotNull(authRes);
-        Assert.Equal(createRes.M2MClient.ClientId, authRes.ClientId);
-
-        // Cleanup
-        customClient.Dispose();
     }
 }

--- a/Stytch.net.Tests/Clients/M2M.cs
+++ b/Stytch.net.Tests/Clients/M2M.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.IdentityModel.Tokens;
+using Stytch.net.Clients;
 using Stytch.net.Exceptions;
 using Stytch.net.Models;
 
@@ -134,5 +135,41 @@ public class M2M : ConsumerTestBase, IAsyncLifetime
 
         // Assert
         Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public async Task M2MAuthenticateToken_SuccessWithCustomDomain()
+    {
+        // This test verifies that when a custom domain is configured,
+        // the AuthenticateJwtLocal method accepts tokens with custom issuers
+        // Note: This test uses standard Stytch tokens, but documents the custom domain support
+
+        // Arrange - Create a client config with custom domain
+        string? projectId = Environment.GetEnvironmentVariable("PROJECT_ID");
+        string? projectSecret = Environment.GetEnvironmentVariable("PROJECT_SECRET");
+
+        if (string.IsNullOrEmpty(projectId) || string.IsNullOrEmpty(projectSecret))
+        {
+            throw new InvalidOperationException("Required environment variables not set.");
+        }
+
+        var customConfig = new ClientConfig
+        {
+            ProjectId = projectId,
+            ProjectSecret = projectSecret,
+            CustomBaseUrl = "https://login.example.com" // Custom domain that would issue tokens
+        };
+
+        var customClient = new Stytch.net.Clients.ConsumerClient(customConfig);
+
+        // Act - Authenticate with standard token (custom domain tokens would work the same way)
+        var authRes = await customClient.M2M.AuthenticateToken(new M2MAuthenticateTokenRequest(tokenRes.AccessToken));
+
+        // Assert - Token validation succeeds with custom domain configured
+        Assert.NotNull(authRes);
+        Assert.Equal(createRes.M2MClient.ClientId, authRes.ClientId);
+
+        // Cleanup
+        customClient.Dispose();
     }
 }

--- a/Stytch.net.Tests/Utility/JwtMultipleIssuersTests.cs
+++ b/Stytch.net.Tests/Utility/JwtMultipleIssuersTests.cs
@@ -1,0 +1,101 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
+using Microsoft.IdentityModel.Tokens;
+using Stytch.net.Clients;
+
+namespace Stytch.net.Tests.Utility;
+
+public class JwtMultipleIssuersTests : IDisposable
+{
+    private readonly RSA _rsa;
+    private readonly RsaSecurityKey _securityKey;
+    private readonly SigningCredentials _signingCredentials;
+    private readonly string _projectId = "project-test-11111111-1111-1111-1111-111111111111";
+    private readonly string _customDomain = "https://login.example.com";
+
+    public JwtMultipleIssuersTests()
+    {
+        _rsa = RSA.Create(2048);
+        _securityKey = new RsaSecurityKey(_rsa);
+        _signingCredentials = new SigningCredentials(_securityKey, SecurityAlgorithms.RsaSha256);
+    }
+
+    public void Dispose()
+    {
+        _rsa?.Dispose();
+    }
+
+    private string CreateTestJwt(string issuer, string audience, Dictionary<string, object>? customClaims = null)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var tokenDescriptor = new SecurityTokenDescriptor
+        {
+            Subject = new System.Security.Claims.ClaimsIdentity(new[]
+            {
+                new System.Security.Claims.Claim(JwtRegisteredClaimNames.Sub, "test-user-id"),
+                new System.Security.Claims.Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+            }),
+            Expires = DateTime.UtcNow.AddHours(1),
+            IssuedAt = DateTime.UtcNow,
+            NotBefore = DateTime.UtcNow,
+            Issuer = issuer,
+            Audience = audience,
+            SigningCredentials = _signingCredentials,
+            Claims = customClaims
+        };
+
+        var token = tokenHandler.CreateToken(tokenDescriptor);
+        return tokenHandler.WriteToken(token);
+    }
+
+    private ClientConfig CreateConfigWithCustomDomain(string customBaseUrl)
+    {
+        return new ClientConfig
+        {
+            ProjectId = _projectId,
+            ProjectSecret = "secret",
+            CustomBaseUrl = customBaseUrl
+        };
+    }
+
+    private ClientConfig CreateStandardConfig()
+    {
+        return new ClientConfig
+        {
+            ProjectId = _projectId,
+            ProjectSecret = "secret"
+        };
+    }
+
+    [Fact]
+    public void AuthenticateJwtLocal_CustomDomainWithTrailingSlash_RemovesTrailingSlash()
+    {
+        // Arrange
+        var customDomainWithSlash = "https://login.example.com/";
+        var config = CreateConfigWithCustomDomain(customDomainWithSlash);
+
+        // The implementation should remove trailing slashes from custom domains
+        // to match issuer format (issuers never have trailing slashes)
+        var expectedDomain = customDomainWithSlash.TrimEnd('/');
+
+        Assert.Equal(customDomainWithSlash, config.CustomBaseUrl);
+        Assert.NotEqual(expectedDomain, config.CustomBaseUrl);
+
+        // After TrimEnd('/') is applied in AuthenticateJwtLocal, they should match
+        Assert.Equal(expectedDomain, config.CustomBaseUrl.TrimEnd('/'));
+    }
+
+    [Theory]
+    [InlineData("https://login.example.com")]
+    [InlineData("https://auth.example.org")]
+    [InlineData("https://custom.stytch-domain.io")]
+    public void AuthenticateJwtLocal_VariousCustomDomains_AreSupported(string customDomain)
+    {
+        // Arrange
+        var config = CreateConfigWithCustomDomain(customDomain);
+
+        // Assert - The configuration should accept various custom domain formats
+        Assert.NotNull(config.CustomBaseUrl);
+        Assert.Equal(customDomain, config.CustomBaseUrl);
+    }
+}

--- a/Stytch.net/Stytch.net.csproj
+++ b/Stytch.net/Stytch.net.csproj
@@ -8,7 +8,7 @@
 <PackageId>Stytch.net</PackageId>
 <AssemblyTitle>Stytch.net</AssemblyTitle>
 <AssemblyName>Stytch.net</AssemblyName>
-    <Version>3.1.0</Version>
+<Version>3.2.0</Version>
 <Author>Stytch</Author>
 <Product>Stytch</Product>
 <PackageProjectUrl>https://github.com/stytchauth/stytch-dotnet</PackageProjectUrl>

--- a/Stytch.net/Utility/Utility.cs
+++ b/Stytch.net/Utility/Utility.cs
@@ -64,11 +64,20 @@ namespace Stytch.net
             AuthenticateJwtParams requestParams)
         {
             var jwks = await GetJwksFromUrl(client, config.JwksUri);
+
+            // Build list of allowed issuers: default issuer and custom base URL (if provided)
+            var allowedIssuers = new List<string> { $"stytch.com/{config.ProjectId}" };
+            if (!string.IsNullOrEmpty(config.CustomBaseUrl))
+            {
+                // Remove trailing slash - our issuers will never have a trailing slash
+                allowedIssuers.Add(config.CustomBaseUrl.TrimEnd('/'));
+            }
+
             var validationParameters = new TokenValidationParameters
             {
                 IssuerSigningKeys = jwks.Keys,
                 ValidateIssuer = true,
-                ValidIssuer = $"stytch.com/{config.ProjectId}",
+                ValidIssuers = allowedIssuers,
                 ValidateAudience = true,
                 ValidAudience = config.ProjectId,
                 ValidateLifetime = true,


### PR DESCRIPTION
Update JWT validation to accept multiple issuers: the default stytch.com/{project_id} and custom base URLs. This fixes SecurityTokenInvalidIssuerException when validating M2M tokens issued from custom domains like login.company.com.

Fixes #56 