### PR TITLE
chore: migrate GitHub runners to ubuntu-latest-public

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     name: Build and publish stytch package to NuGet
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test-stytch:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-public
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Migrates all `ubuntu-latest` runner references to `ubuntu-latest-public` (org-scoped GitHub-hosted runner group).